### PR TITLE
:zap: Store sessionData as binary blob in MongoDB

### DIFF
--- a/mongo/request_manager.go
+++ b/mongo/request_manager.go
@@ -3,6 +3,7 @@ package mongo
 import (
 	// Standard Library Imports
 	"context"
+	"encoding/json"
 	"time"
 
 	// External Imports
@@ -598,6 +599,7 @@ func (r *RequestManager) RevokeAccessToken(ctx context.Context, requestID string
 // be a strict 'signature', for example, authorization code grant passes in an
 // authorization code.
 func toMongo(signature string, r fosite.Requester) storage.Request {
+	session, _ := json.Marshal(r.GetSession())
 	return storage.Request{
 		ID:            r.GetID(),
 		RequestedAt:   r.GetRequestedAt(),
@@ -607,6 +609,6 @@ func toMongo(signature string, r fosite.Requester) storage.Request {
 		Scopes:        r.GetRequestedScopes(),
 		GrantedScopes: r.GetGrantedScopes(),
 		Form:          r.GetRequestForm(),
-		Session:       r.GetSession(),
+		Session:       session,
 	}
 }


### PR DESCRIPTION
Although MongoDB can store arbitrary data, it can't be unmarshalled back into fosite.Storage as part of retrieving the Request from MongoDB.  This commit restores the previous workaround of storing sessionData as a binary blob and unmarshalling it manually.