### PR TITLE
:ship: v0.18.0 - 2019-01-24

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: go
 go_import_path: github.com/matthewhartstonge/storage
 go:
-  - '1.8'
   - '1.9'
   - '1.10'
+  - '1.11'
 
 services:
   - mongodb
@@ -14,7 +14,7 @@ before_install:
   - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 
 install:
-  - dep ensure
+  - dep ensure -v
 
 script:
   - $GOPATH/bin/goveralls -service=travis-ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,25 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [v0.18.0] - 2019-01-24
+### Added
+- Support for testing under Go 1.11
+
+### Changed
+- Adds support for Fosite `v0.27.x`
+- `Client`: Now has an `AllowedAudiences` attribute to comply to the new 
+  interface method required for `fosite.Client`.
+- `Request`: Changed attribute `Scopes` to `RequestedScope`. bson, json and xml 
+  tags remain the same.
+- `Request`: Changed attribute `GrantedScopes` to `GrantedScope`. bson, json and
+   xml tags remain the same.
+
 ### Fixed
 - Fixes the last golint error which was not reported when run locally.
+- Fixes ineffassign issues reported via goreportcard.
+
+### Removed
+- Support for testing under Go 1.8
 
 ## [v0.17.0] - 2018-11-07
 ### Changed
@@ -365,6 +382,7 @@ clear out the password field before sending the response.
 - General pre-release!
 
 [Unreleased]: https://github.com/matthewhartstonge/storage/tree/master
+[v0.18.0]: https://github.com/matthewhartstonge/storage/tree/v0.18.0
 [v0.17.0]: https://github.com/matthewhartstonge/storage/tree/v0.17.0
 [v0.16.0]: https://github.com/matthewhartstonge/storage/tree/v0.16.0
 [v0.15.0]: https://github.com/matthewhartstonge/storage/tree/v0.15.0

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -68,7 +68,7 @@
   version = "v1.0.2"
 
 [[projects]]
-  digest = "1:8f82311ca28ababcec8951d47d95572881192adaf58d0537785187245057e592"
+  digest = "1:55284d4d9455b71f70eec7d7c3e6ac554f21a909d5636d1ef3405552c898aff4"
   name = "github.com/ory/fosite"
   packages = [
     ".",
@@ -79,8 +79,8 @@
     "token/jwt",
   ]
   pruneopts = "UT"
-  revision = "799fc70a48b68b3403eb150084c28d4e78c035e4"
-  version = "v0.26.1"
+  revision = "25cc6c42e2befe3b200d79c9d8edac47cc6d3f86"
+  version = "v0.27.4"
 
 [[projects]]
   digest = "1:625d3085f32f0b3ff11aa3a44a4b4d979c60cfefa49db9008a57d0017d11deee"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,7 +31,7 @@
 # Framework required dependencies
 [[constraint]]
   name = "github.com/ory/fosite"
-  version = "0.26.1"
+  version = "0.27.4"
 
 # Project Dependencies
 [[constraint]]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ know what versions you are successfully paired with.
 
 | storage version | minimum fosite version | maximum fosite version | 
 |----------------:|-----------------------:|-----------------------:|
+|       `v0.18.X` |              `v0.27.X` |              `v0.27.X` |
 |       `v0.17.X` |              `v0.26.X` |              `v0.26.X` |
 |       `v0.16.X` |              `v0.25.X` |              `v0.25.X` |
 |       `v0.15.X` |              `v0.23.X` |              `v0.24.X` |
@@ -151,7 +152,7 @@ func mustRSAKey() *rsa.PrivateKey {
 
 
 ## Disclaimer
-* We are currently using this project in house with Fosite `v0.13.X`
+* We are currently using this project in house with Fosite `v0.17.X`
 * My aim is to keep storage to date with Fosite releases, as always though, my 
     time is limited due to my human frame. 
 * If you are able to provide help in keeping storage up to date, feel free to 

--- a/client.go
+++ b/client.go
@@ -17,6 +17,10 @@ type Client struct {
 	// the epoch.
 	UpdateTime int64 `bson:"updateTime" json:"updateTime" xml:"updateTime"`
 
+	// AllowedAudiences contains a list of Audiences that the client has been
+	// given rights to access.
+	AllowedAudiences []string `bson:"allowedAudiences" json:"allowedAudiences,omitempty" xml:"allowedAudiences,omitempty"`
+
 	// AllowedTenantAccess contains a list of Tenants that the client has been
 	// given rights to access.
 	AllowedTenantAccess []string `bson:"allowedTenantAccess" json:"allowedTenantAccess,omitempty" xml:"allowedTenantAccess,omitempty"`
@@ -162,6 +166,11 @@ func (c *Client) IsPublic() bool {
 	return c.Public
 }
 
+// GetAudience returns the allowed audience(s) for this client.
+func (c *Client) GetAudience() fosite.Arguments {
+	return fosite.Arguments(c.AllowedAudiences)
+}
+
 // IsDisabled returns a boolean as to whether the Client itself has had it's
 // access disabled.
 func (c *Client) IsDisabled() bool {
@@ -241,6 +250,10 @@ func (c Client) Equal(x Client) bool {
 	}
 
 	if c.UpdateTime != x.UpdateTime {
+		return false
+	}
+
+	if !stringArrayEquals(c.AllowedAudiences, x.AllowedAudiences) {
 		return false
 	}
 

--- a/mongo/cache_manager.go
+++ b/mongo/cache_manager.go
@@ -43,7 +43,6 @@ func (c *CacheManager) configureAccessTokensCollection(ctx context.Context) erro
 	mgoSession, ok := ContextToMgoSession(ctx)
 	if !ok {
 		mgoSession = c.DB.Session.Copy()
-		ctx = MgoSessionToContext(ctx, mgoSession)
 		defer mgoSession.Close()
 	}
 
@@ -96,7 +95,6 @@ func (c *CacheManager) configureRefreshTokensCollection(ctx context.Context) err
 	mgoSession, ok := ContextToMgoSession(ctx)
 	if !ok {
 		mgoSession = c.DB.Session.Copy()
-		ctx = MgoSessionToContext(ctx, mgoSession)
 		defer mgoSession.Close()
 	}
 
@@ -158,7 +156,7 @@ func (c *CacheManager) getConcrete(ctx context.Context, entityName, key string) 
 	}
 
 	// Trace how long the Mongo operation takes to complete.
-	span, ctx := traceMongoCall(ctx, dbTrace{
+	span, _ := traceMongoCall(ctx, dbTrace{
 		Manager: "CacheManager",
 		Method:  "getConcrete",
 		Query:   query,
@@ -206,7 +204,7 @@ func (c *CacheManager) Create(ctx context.Context, entityName string, cacheObjec
 	}
 
 	// Trace how long the Mongo operation takes to complete.
-	span, ctx := traceMongoCall(ctx, dbTrace{
+	span, _ := traceMongoCall(ctx, dbTrace{
 		Manager: "CacheManager",
 		Method:  "Create",
 	})
@@ -267,7 +265,7 @@ func (c *CacheManager) Update(ctx context.Context, entityName string, updatedCac
 	}
 
 	// Trace how long the Mongo operation takes to complete.
-	span, ctx := traceMongoCall(ctx, dbTrace{
+	span, _ := traceMongoCall(ctx, dbTrace{
 		Manager:  "CacheManager",
 		Method:   "Update",
 		Selector: selector,
@@ -367,7 +365,7 @@ func (c *CacheManager) DeleteByValue(ctx context.Context, entityName string, val
 	}
 
 	// Trace how long the Mongo operation takes to complete.
-	span, ctx := traceMongoCall(ctx, dbTrace{
+	span, _ := traceMongoCall(ctx, dbTrace{
 		Manager: "ClientManager",
 		Method:  "DeleteByValue",
 		Query:   query,

--- a/mongo/cache_manager_test.go
+++ b/mongo/cache_manager_test.go
@@ -49,7 +49,7 @@ func TestCacheManager_Create_ShouldConflict(t *testing.T) {
 		AssertError(t, got, expected, "cache object not equal")
 	}
 
-	got, err = store.CacheManager.Create(ctx, storage.EntityCacheAccessTokens, expected)
+	_, err = store.CacheManager.Create(ctx, storage.EntityCacheAccessTokens, expected)
 	if err == nil {
 		AssertError(t, err, nil, "create should return an error on conflict")
 	}

--- a/mongo/client_manager.go
+++ b/mongo/client_manager.go
@@ -41,7 +41,6 @@ func (c *ClientManager) Configure(ctx context.Context) error {
 	mgoSession, ok := ContextToMgoSession(ctx)
 	if !ok {
 		mgoSession = c.DB.Session.Copy()
-		ctx = MgoSessionToContext(ctx, mgoSession)
 		defer mgoSession.Close()
 	}
 
@@ -88,7 +87,7 @@ func (c *ClientManager) getConcrete(ctx context.Context, clientID string) (resul
 	}
 
 	// Trace how long the Mongo operation takes to complete.
-	span, ctx := traceMongoCall(ctx, dbTrace{
+	span, _ := traceMongoCall(ctx, dbTrace{
 		Manager: "ClientManager",
 		Method:  "getConcrete",
 		Query:   query,
@@ -160,7 +159,7 @@ func (c *ClientManager) List(ctx context.Context, filter storage.ListClientsRequ
 	}
 
 	// Trace how long the Mongo operation takes to complete.
-	span, ctx := traceMongoCall(ctx, dbTrace{
+	span, _ := traceMongoCall(ctx, dbTrace{
 		Manager: "ClientManager",
 		Method:  "List",
 		Query:   query,
@@ -214,7 +213,7 @@ func (c *ClientManager) Create(ctx context.Context, client storage.Client) (resu
 	client.Secret = string(hash)
 
 	// Trace how long the Mongo operation takes to complete.
-	span, ctx := traceMongoCall(ctx, dbTrace{
+	span, _ := traceMongoCall(ctx, dbTrace{
 		Manager: "ClientManager",
 		Method:  "Create",
 	})
@@ -313,7 +312,7 @@ func (c *ClientManager) Update(ctx context.Context, clientID string, updatedClie
 	}
 
 	// Trace how long the Mongo operation takes to complete.
-	span, ctx := traceMongoCall(ctx, dbTrace{
+	span, _ := traceMongoCall(ctx, dbTrace{
 		Manager:  "ClientManager",
 		Method:   "Update",
 		Selector: selector,
@@ -378,7 +377,7 @@ func (c *ClientManager) Migrate(ctx context.Context, migratedClient storage.Clie
 	}
 
 	// Trace how long the Mongo operation takes to complete.
-	span, ctx := traceMongoCall(ctx, dbTrace{
+	span, _ := traceMongoCall(ctx, dbTrace{
 		Manager:  "ClientManager",
 		Method:   "Migrate",
 		Selector: selector,
@@ -437,7 +436,7 @@ func (c *ClientManager) Delete(ctx context.Context, clientID string) error {
 	}
 
 	// Trace how long the Mongo operation takes to complete.
-	span, ctx := traceMongoCall(ctx, dbTrace{
+	span, _ := traceMongoCall(ctx, dbTrace{
 		Manager: "ClientManager",
 		Method:  "Delete",
 		Query:   query,

--- a/mongo/client_manager_test.go
+++ b/mongo/client_manager_test.go
@@ -21,6 +21,10 @@ func expectedClient() storage.Client {
 		ID:         uuid.New(),
 		CreateTime: time.Now().Unix(),
 		UpdateTime: time.Now().Unix() + 600,
+		AllowedAudiences: []string{
+			uuid.New(),
+			uuid.New(),
+		},
 		AllowedTenantAccess: []string{
 			uuid.New(),
 			uuid.New(),

--- a/mongo/request_manager.go
+++ b/mongo/request_manager.go
@@ -45,7 +45,6 @@ func (r *RequestManager) Configure(ctx context.Context) error {
 	mgoSession, ok := ContextToMgoSession(ctx)
 	if !ok {
 		mgoSession = r.DB.Session.Copy()
-		ctx = MgoSessionToContext(ctx, mgoSession)
 		defer mgoSession.Close()
 	}
 
@@ -130,7 +129,7 @@ func (r *RequestManager) getConcrete(ctx context.Context, entityName string, req
 	}
 
 	// Trace how long the Mongo operation takes to complete.
-	span, ctx := traceMongoCall(ctx, dbTrace{
+	span, _ := traceMongoCall(ctx, dbTrace{
 		Manager: "RequestManager",
 		Method:  "getConcrete",
 		Query:   query,
@@ -193,7 +192,7 @@ func (r *RequestManager) List(ctx context.Context, entityName string, filter sto
 	}
 
 	// Trace how long the Mongo operation takes to complete.
-	span, ctx := traceMongoCall(ctx, dbTrace{
+	span, _ := traceMongoCall(ctx, dbTrace{
 		Manager: "RequestManager",
 		Method:  "List",
 		Query:   query,
@@ -243,7 +242,7 @@ func (r *RequestManager) Create(ctx context.Context, entityName string, request 
 	}
 
 	// Trace how long the Mongo operation takes to complete.
-	span, ctx := traceMongoCall(ctx, dbTrace{
+	span, _ := traceMongoCall(ctx, dbTrace{
 		Manager: "RequestManager",
 		Method:  "Create",
 	})
@@ -299,7 +298,7 @@ func (r *RequestManager) GetBySignature(ctx context.Context, entityName string, 
 	}
 
 	// Trace how long the Mongo operation takes to complete.
-	span, ctx := traceMongoCall(ctx, dbTrace{
+	span, _ := traceMongoCall(ctx, dbTrace{
 		Manager: "RequestManager",
 		Method:  "GetBySignature",
 		Query:   query,
@@ -353,7 +352,7 @@ func (r *RequestManager) Update(ctx context.Context, entityName string, requestI
 	}
 
 	// Trace how long the Mongo operation takes to complete.
-	span, ctx := traceMongoCall(ctx, dbTrace{
+	span, _ := traceMongoCall(ctx, dbTrace{
 		Manager:  "RequestManager",
 		Method:   "Update",
 		Selector: selector,
@@ -404,7 +403,7 @@ func (r *RequestManager) Delete(ctx context.Context, entityName string, requestI
 	}
 
 	// Trace how long the Mongo operation takes to complete.
-	span, ctx := traceMongoCall(ctx, dbTrace{
+	span, _ := traceMongoCall(ctx, dbTrace{
 		Manager: "RequestManager",
 		Method:  "Delete",
 		Query:   query,
@@ -454,7 +453,7 @@ func (r *RequestManager) DeleteBySignature(ctx context.Context, entityName strin
 	}
 
 	// Trace how long the Mongo operation takes to complete.
-	span, ctx := traceMongoCall(ctx, dbTrace{
+	span, _ := traceMongoCall(ctx, dbTrace{
 		Manager: "RequestManager",
 		Method:  "DeleteBySignature",
 		Query:   query,
@@ -615,14 +614,17 @@ func (r *RequestManager) RevokeAccessToken(ctx context.Context, requestID string
 func toMongo(signature string, r fosite.Requester) storage.Request {
 	session, _ := json.Marshal(r.GetSession())
 	return storage.Request{
-		ID:            r.GetID(),
-		RequestedAt:   r.GetRequestedAt(),
-		Signature:     signature,
-		ClientID:      r.GetClient().GetID(),
-		UserID:        r.GetSession().GetSubject(),
-		Scopes:        r.GetRequestedScopes(),
-		GrantedScopes: r.GetGrantedScopes(),
-		Form:          r.GetRequestForm(),
-		Session:       session,
+		ID:                r.GetID(),
+		RequestedAt:       r.GetRequestedAt(),
+		Signature:         signature,
+		ClientID:          r.GetClient().GetID(),
+		UserID:            r.GetSession().GetSubject(),
+		RequestedScope:    r.GetRequestedScopes(),
+		GrantedScope:      r.GetGrantedScopes(),
+		RequestedAudience: r.GetRequestedAudience(),
+		GrantedAudience:   r.GetGrantedAudience(),
+		Form:              r.GetRequestForm(),
+		Active:            false,
+		Session:           session,
 	}
 }

--- a/mongo/user_manager.go
+++ b/mongo/user_manager.go
@@ -40,7 +40,6 @@ func (u *UserManager) Configure(ctx context.Context) error {
 	mgoSession, ok := ContextToMgoSession(ctx)
 	if !ok {
 		mgoSession = u.DB.Session.Copy()
-		ctx = MgoSessionToContext(ctx, mgoSession)
 		defer mgoSession.Close()
 	}
 
@@ -101,7 +100,7 @@ func (u *UserManager) getConcrete(ctx context.Context, userID string) (result st
 	}
 
 	// Trace how long the Mongo operation takes to complete.
-	span, ctx := traceMongoCall(ctx, dbTrace{
+	span, _ := traceMongoCall(ctx, dbTrace{
 		Manager: "UserManager",
 		Method:  "getConcrete",
 		Query:   query,
@@ -173,7 +172,7 @@ func (u *UserManager) List(ctx context.Context, filter storage.ListUsersRequest)
 	}
 
 	// Trace how long the Mongo operation takes to complete.
-	span, ctx := traceMongoCall(ctx, dbTrace{
+	span, _ := traceMongoCall(ctx, dbTrace{
 		Manager: "UserManager",
 		Method:  "List",
 		Query:   query,
@@ -228,7 +227,7 @@ func (u *UserManager) Create(ctx context.Context, user storage.User) (result sto
 	user.Password = string(hash)
 
 	// Trace how long the Mongo operation takes to complete.
-	span, ctx := traceMongoCall(ctx, dbTrace{
+	span, _ := traceMongoCall(ctx, dbTrace{
 		Manager: "UserManager",
 		Method:  "Create",
 	})
@@ -284,7 +283,7 @@ func (u *UserManager) GetByUsername(ctx context.Context, username string) (resul
 	}
 
 	// Trace how long the Mongo operation takes to complete.
-	span, ctx := traceMongoCall(ctx, dbTrace{
+	span, _ := traceMongoCall(ctx, dbTrace{
 		Manager: "UserManager",
 		Method:  "getConcrete",
 		Query:   query,
@@ -361,7 +360,7 @@ func (u *UserManager) Update(ctx context.Context, userID string, updatedUser sto
 	}
 
 	// Trace how long the Mongo operation takes to complete.
-	span, ctx := traceMongoCall(ctx, dbTrace{
+	span, _ := traceMongoCall(ctx, dbTrace{
 		Manager:  "UserManager",
 		Method:   "Update",
 		Selector: selector,
@@ -433,7 +432,7 @@ func (u *UserManager) Migrate(ctx context.Context, migratedUser storage.User) (r
 	}
 
 	// Trace how long the Mongo operation takes to complete.
-	span, ctx := traceMongoCall(ctx, dbTrace{
+	span, _ := traceMongoCall(ctx, dbTrace{
 		Manager:  "UserManager",
 		Method:   "Migrate",
 		Selector: selector,
@@ -484,7 +483,7 @@ func (u *UserManager) Delete(ctx context.Context, userID string) error {
 	}
 
 	// Trace how long the Mongo operation takes to complete.
-	span, ctx := traceMongoCall(ctx, dbTrace{
+	span, _ := traceMongoCall(ctx, dbTrace{
 		Manager: "UserManager",
 		Method:  "Delete",
 		Query:   query,

--- a/request.go
+++ b/request.go
@@ -35,10 +35,15 @@ type Request struct {
 	// user account.
 	UserID string `bson:"userId" json:"userId" xml:"userId"`
 	// Scopes contains the scopes that the user requested.
-	Scopes fosite.Arguments `bson:"scopes" json:"scopes" xml:"scopes"`
-	// GrantedScopes contains the list of scopes that the user was actually
+	RequestedScope fosite.Arguments `bson:"scopes" json:"scopes" xml:"scopes"`
+	// GrantedScope contains the list of scopes that the user was actually
 	// granted.
-	GrantedScopes fosite.Arguments `bson:"grantedScopes" json:"grantedScopes" xml:"grantedScopes"`
+	GrantedScope fosite.Arguments `bson:"grantedScopes" json:"grantedScopes" xml:"grantedScopes"`
+	// RequestedAudience contains the audience the user requested.
+	RequestedAudience fosite.Arguments `bson:"requestedAudience" json:"requestedAudience" xml:"requestedAudience"`
+	// GrantedAudience contains the list of audiences the user was actually
+	// granted.
+	GrantedAudience fosite.Arguments `bson:"grantedAudience" json:"grantedAudience" xml:"grantedAudience"`
 	// Form contains the url values that were passed in to authenticate the
 	// user's client session.
 	Form url.Values `bson:"formData" json:"formData" xml:"formData"`
@@ -54,16 +59,16 @@ type Request struct {
 // NewRequest returns a new Mongo Store request object.
 func NewRequest() Request {
 	return Request{
-		ID:            uuid.New(),
-		RequestedAt:   time.Now(),
-		Signature:     "",
-		ClientID:      "",
-		UserID:        "",
-		Scopes:        []string{},
-		GrantedScopes: []string{},
-		Form:          make(url.Values),
-		Active:        true,
-		Session:       nil,
+		ID:             uuid.New(),
+		RequestedAt:    time.Now(),
+		Signature:      "",
+		ClientID:       "",
+		UserID:         "",
+		RequestedScope: fosite.Arguments{},
+		GrantedScope:   fosite.Arguments{},
+		Form:           make(url.Values),
+		Active:         true,
+		Session:        nil,
 	}
 }
 
@@ -83,13 +88,15 @@ func (r *Request) ToRequest(ctx context.Context, session fosite.Session, cm Clie
 	}
 
 	req := &fosite.Request{
-		ID:            r.ID,
-		RequestedAt:   r.RequestedAt,
-		Client:        client,
-		Scopes:        r.Scopes,
-		GrantedScopes: r.GrantedScopes,
-		Form:          r.Form,
-		Session:       session,
+		ID:                r.ID,
+		RequestedAt:       r.RequestedAt,
+		Client:            client,
+		RequestedScope:    r.RequestedScope,
+		GrantedScope:      r.GrantedScope,
+		Form:              r.Form,
+		Session:           session,
+		RequestedAudience: r.RequestedAudience,
+		GrantedAudience:   r.GrantedAudience,
 	}
 	return req, nil
 }


### PR DESCRIPTION
Added:
- Support for testing under Go 1.11

Changed:
- Adds support for Fosite `v0.27.x`
- `Client`: Now has an `AllowedAudiences` attribute to comply to the
  new interface method required for `fosite.Client`.
- `Request`: Changed attribute `Scopes` to `RequestedScope`. bson, json
  and xml tags remain the same.
- `Request`: Changed attribute `GrantedScopes` to `GrantedScope`. bson,
  json and xml tags remain the same.

Fixed:
- Fixes the last golint error which was not reported when run locally.
- Fixes ineffassign issues reported via goreportcard.

Removed:
- Support for testing under Go 1.8

Fixes #21.
Fixes #22.