### PR TITLE
v0.18.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: go
 sudo: false
 go:
-  - 1.11.x
-  - 1.12.x
-  - 1.13.x
+  - '1.13'
+  - '1.14'
+  - 'tip'
 
 services:
   - mongodb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,22 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [v0.18.7] - 2020-05-24
+### Changed
+- travisci: updated to test against `go@{1.14, tip}`
+
 ### Fixed
 - mongo: fixed `ineffassign` and `staticcheck` issues.
 - mongo: fixed `maligned` issues reducing config struct memory allocation from 
   138 bytes to 127 bytes.
 - mongo: fixed missed error check.
 - mongo: fixed `lint` issues where context was not the first parameter.
+- mongo: fixed user delete test creating a client instead of a user for 
+  deletion.
+- mongo: fixed create client parameter ordering.
+
+### Removed
+- travisci: support for go < 1.13
 
 ## [v0.18.6] - 2019-09-25
 ### Added
@@ -437,6 +447,7 @@ clear out the password field before sending the response.
 - General pre-release!
 
 [Unreleased]: https://github.com/matthewhartstonge/storage/tree/master
+[v0.18.7]: https://github.com/matthewhartstonge/storage/tree/v0.18.7
 [v0.18.6]: https://github.com/matthewhartstonge/storage/tree/v0.18.6
 [v0.18.5]: https://github.com/matthewhartstonge/storage/tree/v0.18.5
 [v0.18.4]: https://github.com/matthewhartstonge/storage/tree/v0.18.4

--- a/mongo/client_manager_test.go
+++ b/mongo/client_manager_test.go
@@ -21,7 +21,7 @@ func TestClientManager_List(t *testing.T) {
 	defer teardown()
 
 	// generate our expected data.
-	expected := createClient(t, ctx, store)
+	expected := createClient(ctx, t, store)
 
 	publishedClient := storage.Client{
 		ID:                  uuid.New(),

--- a/mongo/user_manager_test.go
+++ b/mongo/user_manager_test.go
@@ -255,7 +255,7 @@ func TestUserManager_Delete(t *testing.T) {
 	store, ctx, teardown := setup(t)
 	defer teardown()
 
-	expected := createClient(ctx, t, store)
+	expected := createUser(ctx, t, store)
 
 	err := store.UserManager.Delete(ctx, expected.ID)
 	if err != nil {


### PR DESCRIPTION
## [v0.18.7] - 2020-05-24

### Changed
- travisci: updated to test against `go@{1.14, tip}`

### Fixed
- mongo: fixed `ineffassign` and `staticcheck` issues.
- mongo: fixed `maligned` issues reducing config struct memory
  allocation from 138 bytes to 127 bytes.
- mongo: fixed missed error check.
- mongo: fixed `lint` issues where context was not the first
  parameter.
- mongo: fixed user delete test creating a client instead of a
  user for deletion.
- mongo: fixed create client parameter ordering.

### Removed
- travisci: support for go < 1.13

[v0.18.7]: https://github.com/matthewhartstonge/storage/tree/v0.18.7