### PR TITLE
v0.18.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [v0.18.8] - 2020-06-11
+### Fixed
+- mongo: auth codes should be set to active by default on creation.
+
 ## [v0.18.7] - 2020-05-24
 ### Changed
 - travisci: updated to test against `go@{1.14, tip}`
@@ -447,6 +451,7 @@ clear out the password field before sending the response.
 - General pre-release!
 
 [Unreleased]: https://github.com/matthewhartstonge/storage/tree/master
+[v0.18.8]: https://github.com/matthewhartstonge/storage/tree/v0.18.8
 [v0.18.7]: https://github.com/matthewhartstonge/storage/tree/v0.18.7
 [v0.18.6]: https://github.com/matthewhartstonge/storage/tree/v0.18.6
 [v0.18.5]: https://github.com/matthewhartstonge/storage/tree/v0.18.5

--- a/mongo/request_manager.go
+++ b/mongo/request_manager.go
@@ -624,7 +624,7 @@ func toMongo(signature string, r fosite.Requester) storage.Request {
 		RequestedAudience: r.GetRequestedAudience(),
 		GrantedAudience:   r.GetGrantedAudience(),
 		Form:              r.GetRequestForm(),
-		Active:            false,
+		Active:            true,
 		Session:           session,
 	}
 }


### PR DESCRIPTION
## [v0.18.8] - 2020-06-11

### Fixed
- mongo: auth codes should be set to active by default on creation.

[v0.18.8]: https://github.com/matthewhartstonge/storage/tree/v0.18.8