### PR TITLE
v0.18.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- mongo: `RevokeAccessToken` attempted to delete the access token twice from 
+  the datastore leading to `fosite.ErrNotFound` always being returned.
+
 ## [v0.18.8] - 2020-06-11
 ### Fixed
 - mongo: auth codes should be set to active by default on creation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - mongo: `RevokeAccessToken` attempted to delete the access token twice from 
   the datastore leading to `fosite.ErrNotFound` always being returned.
+- mongo: `RevokeRefreshToken` attempted to delete the refresh token twice from 
+  the datastore leading to `fosite.ErrNotFound` always being returned.
 
 ## [v0.18.8] - 2020-06-11
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [v0.18.9] - 2020-06-13
 ### Fixed
 - mongo: `RevokeAccessToken` attempted to delete the access token twice from 
   the datastore leading to `fosite.ErrNotFound` always being returned.
@@ -457,6 +458,7 @@ clear out the password field before sending the response.
 - General pre-release!
 
 [Unreleased]: https://github.com/matthewhartstonge/storage/tree/master
+[v0.18.9]: https://github.com/matthewhartstonge/storage/tree/v0.18.9
 [v0.18.8]: https://github.com/matthewhartstonge/storage/tree/v0.18.8
 [v0.18.7]: https://github.com/matthewhartstonge/storage/tree/v0.18.7
 [v0.18.6]: https://github.com/matthewhartstonge/storage/tree/v0.18.6

--- a/mongo/request_manager.go
+++ b/mongo/request_manager.go
@@ -531,15 +531,6 @@ func (r *RequestManager) RevokeRefreshToken(ctx context.Context, requestID strin
 		return err
 	}
 
-	err = r.Cache.Delete(ctx, storage.EntityCacheRefreshTokens, cacheObject.Key())
-	if err != nil {
-		// Log to StdOut
-		log.WithError(err).Error(logError)
-		// Log to OpenTracing
-		otLogErr(span, err)
-		return err
-	}
-
 	return nil
 }
 

--- a/mongo/request_manager.go
+++ b/mongo/request_manager.go
@@ -595,15 +595,6 @@ func (r *RequestManager) RevokeAccessToken(ctx context.Context, requestID string
 		return err
 	}
 
-	err = r.Cache.Delete(ctx, storage.EntityCacheAccessTokens, cacheObject.Key())
-	if err != nil {
-		// Log to StdOut
-		log.WithError(err).Error(logError)
-		// Log to OpenTracing
-		otLogErr(span, err)
-		return err
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
## [v0.18.9] - 2020-06-13
### Fixed
- mongo: `RevokeAccessToken` attempted to delete the access token twice from the datastore leading to `fosite.ErrNotFound` always being returned.
- mongo: `RevokeRefreshToken` attempted to delete the refresh token twice from the datastore leading to `fosite.ErrNotFound` always being returned.

[v0.18.9]: https://github.com/matthewhartstonge/storage/tree/v0.18.9

Fixes #39.
Fixes #40.