### PR TITLE
:fire: mongo: removes index option `SetBackground` due to being deprecated as of Mongo 4.2.

### DIFF
--- a/mongo/client_manager.go
+++ b/mongo/client_manager.go
@@ -50,7 +50,6 @@ func (c *ClientManager) Configure(ctx context.Context) (err error) {
 				},
 			},
 			Options: options.Index().
-				SetBackground(true).
 				SetName(IdxClientID).
 				SetSparse(true).
 				SetUnique(true),

--- a/mongo/jti_manager.go
+++ b/mongo/jti_manager.go
@@ -40,7 +40,6 @@ func (d *DeniedJtiManager) Configure(ctx context.Context) (err error) {
 			},
 			Options: options.Index().
 				SetName(IdxSignatureID).
-				SetBackground(true).
 				SetSparse(true).
 				SetUnique(true),
 		},
@@ -53,7 +52,6 @@ func (d *DeniedJtiManager) Configure(ctx context.Context) (err error) {
 			},
 			Options: options.Index().
 				SetName(IdxExpires).
-				SetBackground(true).
 				SetSparse(true),
 		},
 	}

--- a/mongo/request_manager.go
+++ b/mongo/request_manager.go
@@ -60,7 +60,6 @@ func (r *RequestManager) Configure(ctx context.Context) (err error) {
 				},
 			},
 			Options: options.Index().
-				SetBackground(true).
 				SetName(IdxSessionID).
 				SetSparse(true).
 				SetUnique(true),
@@ -73,7 +72,6 @@ func (r *RequestManager) Configure(ctx context.Context) (err error) {
 				},
 			},
 			Options: options.Index().
-				SetBackground(true).
 				SetName(IdxSignatureID).
 				SetSparse(true).
 				SetUnique(true),
@@ -90,7 +88,6 @@ func (r *RequestManager) Configure(ctx context.Context) (err error) {
 				},
 			},
 			Options: options.Index().
-				SetBackground(true).
 				SetName(IdxCompoundRequester).
 				SetSparse(true),
 		},

--- a/mongo/user_manager.go
+++ b/mongo/user_manager.go
@@ -47,7 +47,6 @@ func (u *UserManager) Configure(ctx context.Context) (err error) {
 			},
 			Options: options.Index().
 				SetName(IdxUserID).
-				SetBackground(true).
 				SetSparse(true).
 				SetUnique(true),
 		},
@@ -60,7 +59,6 @@ func (u *UserManager) Configure(ctx context.Context) (err error) {
 			},
 			Options: options.Index().
 				SetName(IdxUsername).
-				SetBackground(true).
 				SetSparse(true).
 				SetUnique(true),
 		},


### PR DESCRIPTION
Fixes #47.

Note:
- To be merged @ Mongo 4.0 EOL April 2022.
