### PR TITLE
Feature/access-token-hashed-index

### DIFF
--- a/examples/mongo/authorizationserver/mongo.go
+++ b/examples/mongo/authorizationserver/mongo.go
@@ -29,20 +29,17 @@ func NewExampleMongoStore() *mongo.Store {
 	// know we want to create a couple of clients and a user, therefore, we'll
 	// group that into a server session, if we are using a mongo replica set.
 
-	// If our mongo is running as a replica set and we can use server sessions...
-	if store.DB.HasSessions {
-		// We luckily have `store.NewSession()` which does the hard work for us by
-		// pushing the session into the context so all db handlers can use the same
-		// connection/session and provides a function to be able to cleanly close
-		// the session for us, which we can defer to later.
-		var closeSession func()
-		ctx, closeSession, err = store.NewSession(ctx)
-		if err != nil {
-			// oh noes! creating a mongo session broke :/
-			log.WithError(err).Fatal("error creating new session")
-		}
-		defer closeSession()
+	// If our mongo is running as a replica set we can use mongo sessions.
+	// We luckily have `store.NewSession()` which does the hard work for us by
+	// pushing the session into the context so all db handlers can use the same
+	// connection/session and provides a function to be able to cleanly close
+	// the session for us, which we can defer to later.
+	ctx, closeSession, err := store.NewSession(ctx)
+	if err != nil {
+		// oh noes! creating a mongo session broke :/
+		log.WithError(err).Fatal("error creating new session")
 	}
+	defer closeSession()
 
 	// Inject our test clients
 	clients := []storage.Client{

--- a/mongo/client_manager.go
+++ b/mongo/client_manager.go
@@ -42,19 +42,7 @@ func (c *ClientManager) Configure(ctx context.Context) (err error) {
 
 	// Build Index
 	indices := []mongo.IndexModel{
-		{
-			Keys: bson.D{
-				{
-					Key:   "id",
-					Value: int32(1),
-				},
-			},
-			Options: options.Index().
-				SetBackground(true).
-				SetName(IdxClientID).
-				SetSparse(true).
-				SetUnique(true),
-		},
+		NewUniqueIndex(IdxClientID, "id"),
 	}
 
 	collection := c.DB.Collection(storage.EntityClients)

--- a/mongo/jti_manager.go
+++ b/mongo/jti_manager.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
 
 	// Internal Imports
 	"github.com/matthewhartstonge/storage"
@@ -31,31 +30,8 @@ func (d *DeniedJtiManager) Configure(ctx context.Context) (err error) {
 	})
 
 	indices := []mongo.IndexModel{
-		{
-			Keys: bson.D{
-				{
-					Key:   "signature",
-					Value: int32(1),
-				},
-			},
-			Options: options.Index().
-				SetName(IdxSignatureID).
-				SetBackground(true).
-				SetSparse(true).
-				SetUnique(true),
-		},
-		{
-			Keys: bson.D{
-				{
-					Key:   "exp",
-					Value: int32(1),
-				},
-			},
-			Options: options.Index().
-				SetName(IdxExpires).
-				SetBackground(true).
-				SetSparse(true),
-		},
+		NewUniqueIndex(IdxSignatureID, "signature"),
+		NewIndex(IdxExpires, "exp"),
 	}
 
 	collection := d.DB.Collection(storage.EntityJtiDenylist)

--- a/mongo/request_manager.go
+++ b/mongo/request_manager.go
@@ -6,14 +6,13 @@ import (
 	"encoding/json"
 	"time"
 
-	ot "github.com/opentracing/opentracing-go"
 	// External Imports
 	"github.com/google/uuid"
+	ot "github.com/opentracing/opentracing-go"
 	"github.com/ory/fosite"
 	"github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
 
 	// Internal Imports
 	"github.com/matthewhartstonge/storage"
@@ -52,48 +51,9 @@ func (r *RequestManager) Configure(ctx context.Context) (err error) {
 
 	// Build Indices
 	indices := []mongo.IndexModel{
-		{
-			Keys: bson.D{
-				{
-					Key:   "id",
-					Value: int32(1),
-				},
-			},
-			Options: options.Index().
-				SetBackground(true).
-				SetName(IdxSessionID).
-				SetSparse(true).
-				SetUnique(true),
-		},
-		{
-			Keys: bson.D{
-				{
-					Key:   "signature",
-					Value: int32(1),
-				},
-			},
-			Options: options.Index().
-				SetBackground(true).
-				SetName(IdxSignatureID).
-				SetSparse(true).
-				SetUnique(true),
-		},
-		{
-			Keys: bson.D{
-				{
-					Key:   "clientId",
-					Value: int32(1),
-				},
-				{
-					Key:   "userId",
-					Value: int32(1),
-				},
-			},
-			Options: options.Index().
-				SetBackground(true).
-				SetName(IdxCompoundRequester).
-				SetSparse(true),
-		},
+		NewUniqueIndex(IdxSessionID, "id"),
+		NewIndex(IdxCompoundRequester, "clientId", "userId"),
+		NewUniqueIndex(IdxSignatureID, "signature"),
 	}
 
 	for _, entityName := range collections {

--- a/mongo/user_manager.go
+++ b/mongo/user_manager.go
@@ -38,32 +38,8 @@ func (u *UserManager) Configure(ctx context.Context) (err error) {
 	})
 
 	indices := []mongo.IndexModel{
-		{
-			Keys: bson.D{
-				{
-					Key:   "id",
-					Value: int32(1),
-				},
-			},
-			Options: options.Index().
-				SetName(IdxUserID).
-				SetBackground(true).
-				SetSparse(true).
-				SetUnique(true),
-		},
-		{
-			Keys: bson.D{
-				{
-					Key:   "username",
-					Value: int32(1),
-				},
-			},
-			Options: options.Index().
-				SetName(IdxUsername).
-				SetBackground(true).
-				SetSparse(true).
-				SetUnique(true),
-		},
+		NewUniqueIndex(IdxUserID, "id"),
+		NewUniqueIndex(IdxUsername, "username"),
 	}
 
 	collection := u.DB.Collection(storage.EntityUsers)


### PR DESCRIPTION
mongo: migrates to using a hashed index for the signature index on access tokens.

The signature for an access token could grow quite large, leading to a large index. By migrating to using a hashed index, the size can be reduced to 2% of the original indices size. For example, we achieved a slimming from 2.8GB -> 57MB.