### PR TITLE
Bugfix/example fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - deps: updates `examples/mongo` to `github.com/sirupsen/logrus@v1.8.1`.
 - deps: updates `examples/mongo` to `golang.org/x/net@v0.0.0-20220926192436-02166a98028e`.
 - deps: updates `examples/mongo` to `golang.org/x/oauth2@v0.0.0-20220909003341-f21342109be1`.
+- examples/mongo/authorizationserver: migrates deprecated use of `Exact()` to `ExactOne()`.
+
+### Fixed
+- examples/mongo/authorizationserver: sets session subject and username. Fixes #65.
+- examples/mongo/authorizationserver: properly logs out the generated user id.
 
 ## [v0.30.1] - 2022-08-08
 ### Added

--- a/examples/mongo/authorizationserver/mongo.go
+++ b/examples/mongo/authorizationserver/mongo.go
@@ -133,11 +133,11 @@ func createUsers(ctx context.Context, store *mongo.Store, users []storage.User) 
 		}
 
 		// Create the new user!
-		_, err = store.UserManager.Create(ctx, user)
+		user, err = store.UserManager.Create(ctx, user)
 		if err != nil {
 			// err, it broke... ?
 			panic(err)
 		}
-		logger.Info("new user created!")
+		logger.WithField("id", user.ID).Info("new user created!")
 	}
 }

--- a/examples/mongo/authorizationserver/oauth2.go
+++ b/examples/mongo/authorizationserver/oauth2.go
@@ -101,5 +101,7 @@ func newSession(user string) *openid.DefaultSession {
 		Headers: &jwt.Headers{
 			Extra: make(map[string]interface{}),
 		},
+		Subject:  user,
+		Username: user,
 	}
 }

--- a/examples/mongo/authorizationserver/oauth2_token.go
+++ b/examples/mongo/authorizationserver/oauth2_token.go
@@ -28,7 +28,7 @@ func tokenEndpoint(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	// If this is a client_credentials grant, grant all scopes the client is allowed to perform.
-	if accessRequest.GetGrantTypes().Exact("client_credentials") {
+	if accessRequest.GetGrantTypes().ExactOne("client_credentials") {
 		for _, scope := range accessRequest.GetRequestedScopes() {
 			if fosite.HierarchicScopeStrategy(accessRequest.GetClient().GetScopes(), scope) {
 				accessRequest.GrantScope(scope)


### PR DESCRIPTION
### Changed
- examples/mongo/authorizationserver: migrates deprecated use of `Exact()` to `ExactOne()`.

### Fixed
- examples/mongo/authorizationserver: sets session subject and username. Fixes #65.
- examples/mongo/authorizationserver: properly logs out the generated user id.