### PR TITLE
:bug: mongo/mongo: reduces read errors occurring in a mongo replica set.

### DIFF
--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -15,6 +15,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
+	"go.mongodb.org/mongo-driver/mongo/writeconcern"
 
 	// Local Imports
 	"github.com/matthewhartstonge/storage"
@@ -168,6 +169,7 @@ func ConnectionInfo(cfg *Config) *options.ClientOptions {
 	clientOpts.SetReplicaSet(cfg.Replset).
 		SetConnectTimeout(time.Second * time.Duration(cfg.Timeout)).
 		SetReadPreference(readpref.SecondaryPreferred()).
+		SetWriteConcern(writeconcern.New(writeconcern.WMajority())).
 		SetMinPoolSize(cfg.PoolMinSize).
 		SetMaxPoolSize(cfg.PoolMaxSize).
 		SetCompressors(cfg.Compressors).


### PR DESCRIPTION
This fix helps reduce `invalid_grant` errors from occurring where a read from a user agent is performed (in order to complete the oauth flow) before the session is successfully written to a secondary.

### Current Flow
Currently, the driver is configured to always read from secondaries by setting the mongo clients read concern. This can lead to situations where a read for a session record can occur on a secondary before the record has been replicated from the primary.

![mongo-replication-lag](https://user-images.githubusercontent.com/6119549/211286114-d6a1fa1e-8b16-430f-bc0d-82097e372dbf.png)

### Improved Flow
By setting the write concern to majority, mongo ensures the data is written to a 'calculated' majority of data bearing members of the replica set. This helps to reduce read errors from occurring, but does increase initial sign in due to having to wait for confirmation that the majority of replica members have written the record before progressing.

![mongo-replication-lag-write-concern](https://user-images.githubusercontent.com/6119549/211286133-379257f2-7bd1-4447-bfe0-de7e14e5c3fc.png)

## References
- https://www.mongodb.com/docs/manual/core/replica-set-write-concern/

## Issues
- Fixes #68 