### PR TITLE
Support for testing against `go@1.19` and `mongo@6.0`

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         go: [ '1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19' ]
-        mongo: [ '4.2', '4.4', '5.0' ]
+        mongo: [ '4.2', '4.4', '5.0', '6.0' ]
 
     name: Go ${{ matrix.go }} with MongoDB ${{ matrix.mongo }}
     steps:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,5 +1,5 @@
 name: go
-on: [push, pull_request]
+on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.13', '1.14', '1.15', '1.16', '1.17', '1.18' ]
+        go: [ '1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19' ]
         mongo: [ '4.2', '4.4', '5.0' ]
 
     name: Go ${{ matrix.go }} with MongoDB ${{ matrix.mongo }}

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -61,14 +61,16 @@ type DB struct {
 // NewSession boilerplate becomes:
 // ```
 // ctx := context.Background()
-// if store.DB.HasSessions {
-//     var closeSession func()
-//     ctx, closeSession, err = store.NewSession(nil)
-//     if err != nil {
-//         panic(err)
-//     }
-//     defer closeSession()
-// }
+//
+//	if store.DB.HasSessions {
+//	    var closeSession func()
+//	    ctx, closeSession, err = store.NewSession(nil)
+//	    if err != nil {
+//	        panic(err)
+//	    }
+//	    defer closeSession()
+//	}
+//
 // ```
 func (s *Store) NewSession(ctx context.Context) (context.Context, func(), error) {
 	return newSession(ctx, s.DB)
@@ -342,8 +344,8 @@ func NewDefaultStore() (*Store, error) {
 // NewIndex generates a new index model, ready to be saved in mongo.
 //
 // Note:
-// - This function assumes you are entering valid index keys and relies on
-//   mongo rejecting index operations if a bad index is created.
+//   - This function assumes you are entering valid index keys and relies on
+//     mongo rejecting index operations if a bad index is created.
 func NewIndex(name string, keys ...string) (model mongo.IndexModel) {
 	return mongo.IndexModel{
 		Keys:    generateIndexKeys(keys...),

--- a/storage.go
+++ b/storage.go
@@ -30,12 +30,13 @@ func (s *Store) Authenticate(ctx context.Context, username string, secret string
 // For example, you may have passwords in MD5 and wanting them to be
 // migrated to fosite's default hasher, bcrypt. Therefore, if you do a mass
 // data migration, the function you supply would have to:
-//   +- Shortcut logic if the hash string prefix matches what you expect from
-// 		the new hash
-//   - Get the current client record (return nil, false if not found)
-//   - Authenticate the current DB secret against MD5
-//   - Return the Client record and if the client authenticated.
-//   - if true, the AuthenticateMigration function will upgrade the hash.
+//
+//	  +- Shortcut logic if the hash string prefix matches what you expect from
+//			the new hash
+//	  - Get the current client record (return nil, false if not found)
+//	  - Authenticate the current DB secret against MD5
+//	  - Return the Client record and if the client authenticated.
+//	  - if true, the AuthenticateMigration function will upgrade the hash.
 type AuthClientFunc func(ctx context.Context) (Client, bool)
 
 // AuthUserFunc enables developers to supply their own authentication


### PR DESCRIPTION
Adds support for testing against `go@1.19` and `mongo@6.0`.