### PR TITLE
:ship: v0.32.0 - 2023-07-18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [v0.32.0] - 2023-07-18
+### Added
+- user: Adds support for MFA factors.
+
+### Changed
+- deps: updates to `github.com/opentracing/opentracing-go@v1.2.0`.
+- deps: updates to `github.com/sirupsen/logrus@v1.9.3`.
+- deps: updates to `go.mongodb.org/mongo-driver@v1.12.0`.
+- deps: updates `examples/mongo` to `github.com/sirupsen/logrus@v1.9.3`.
+- deps: updates `examples/mongo` to `golang.org/x/net@v0.12.0`.
+- deps: updates `examples/mongo` to `golang.org/x/oauth2@v0.10.0`.
+
 ## [v0.31.0] - 2023-01-10
 ### Changed
 - deps: updates to `github.com/google/uuid@v1.3.0`.
@@ -690,6 +702,7 @@ clear out the password field before sending the response.
 - General pre-release!
 
 [Unreleased]: https://github.com/matthewhartstonge/storage/tree/master
+[v0.32.0]: https://github.com/matthewhartstonge/storage/tree/v0.32.0
 [v0.31.0]: https://github.com/matthewhartstonge/storage/tree/v0.31.0
 [v0.30.1]: https://github.com/matthewhartstonge/storage/tree/v0.30.1
 [v0.30.0]: https://github.com/matthewhartstonge/storage/tree/v0.30.0

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 Matthew Hartstonge <matt@mykro.co.nz>
+   Copyright 2023 Matthew Hartstonge <matt@mykro.co.nz>
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2021 Matthew Hartstonge <matt@mykro.co.nz>
+Copyright 2023 Matthew Hartstonge <matt@mykro.co.nz>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ know what versions you are successfully paired with.
 
 | storage version | minimum fosite version | maximum fosite version | 
 |----------------:|-----------------------:|-----------------------:|
+|       `v0.32.X` |              `v0.33.X` |              `v0.34.X` |
 |       `v0.31.X` |              `v0.33.X` |              `v0.34.X` |
 |       `v0.30.X` |              `v0.33.X` |              `v0.34.X` |
 |       `v0.29.X` |              `v0.32.X` |              `v0.34.X` |
 |       `v0.28.X` |              `v0.32.X` |              `v0.34.X` |
-|       `v0.27.X` |              `v0.32.X` |              `v0.34.X` |
 
 ## Development
 To start hacking:


### PR DESCRIPTION
Added:
- user: Adds support for MFA factors.

Changed:
- deps: updates to `github.com/opentracing/opentracing-go@v1.2.0`.
- deps: updates to `github.com/sirupsen/logrus@v1.9.3`.
- deps: updates to `go.mongodb.org/mongo-driver@v1.12.0`.
- deps: updates `examples/mongo` to `github.com/sirupsen/logrus@v1.9.3`.
- deps: updates `examples/mongo` to `golang.org/x/net@v0.12.0`.
- deps: updates `examples/mongo` to `golang.org/x/oauth2@v0.10.0`.