### PR TITLE
:ship: v0.35.0 - 2025-07-21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [v0.35.0] - 2025-07-21
+### Changed
+- deps: updates to `go@1.23`.
+- deps: updates to `github.com/ory/fosite@v0.34.1`.
+- deps: updates to `go.mongodb.org/mongo-driver@v1.17.4`.
+- ci: added testing against `go@1.23, 1.24`.
+- ci: added testing against `mongo@8.0`.
+- ci: removed testing against `go@1.13 - go@1.22`.
+- ci: removed testing against `mongo@4.4 - mongo@6.0`.
+
 ## [v0.34.0] - 2024-02-22
 ### Added
 - user: adds support for regions.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2024 Matthew Hartstonge <matt@mykro.co.nz>
+   Copyright 2025 Matthew Hartstonge <matt@mykro.co.nz>
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2024 Matthew Hartstonge <matt@mykro.co.nz>
+Copyright 2025 Matthew Hartstonge <matt@mykro.co.nz>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -17,15 +17,12 @@ know what versions you are successfully paired with.
 
 | storage version | minimum fosite version | maximum fosite version | 
 |----------------:|-----------------------:|-----------------------:|
+|       `v0.35.X` |              `v0.34.X` |              `v0.34.X` |
 |       `v0.34.X` |              `v0.33.X` |              `v0.34.X` |
-|       `v0.33.X` |              `v0.33.X` |              `v0.34.X` |
-|       `v0.32.X` |              `v0.33.X` |              `v0.34.X` |
-|       `v0.31.X` |              `v0.33.X` |              `v0.34.X` |
-|       `v0.30.X` |              `v0.33.X` |              `v0.34.X` |
 
 ## Development
 To start hacking:
-* Install [Go][Go] >1.14
+* Install [Go][Go] >=1.23
     * Use Go modules!
     * `go build` successfully!
 


### PR DESCRIPTION
### Changed
- deps: updates to `go@1.23`.
- deps: updates to `github.com/ory/fosite@v0.34.1`.
- deps: updates to `go.mongodb.org/mongo-driver@v1.17.4`.
- ci: added testing against `go@1.23, 1.24`.
- ci: added testing against `mongo@8.0`.
- ci: removed testing against `go@1.13 - go@1.22`.
- ci: removed testing against `mongo@4.4 - mongo@6.0`.

